### PR TITLE
support react >=16.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fengweichong/react-native-gzip",
   "title": "React Native Gzip",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "解压缩gzip和tar格式文件",
   "main": "index.js",
   "files": [
@@ -31,7 +31,7 @@
   "licenseFilename": "LICENSE",
   "readmeFilename": "README.md",
   "peerDependencies": {
-    "react": "^16.8.1",
+    "react": ">=16.8.1",
     "react-native": ">=0.60.0-rc.0 <1.0.x"
   },
   "devDependencies": {


### PR DESCRIPTION
When trying to install with a new created project I get the following error

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: testapp@0.0.1
npm ERR! Found: react@18.1.0
npm ERR! node_modules/react
npm ERR!   react@"18.1.0" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^16.8.1" from @fengweichong/react-native-gzip@2.0.0
npm ERR! node_modules/@fengweichong/react-native-gzip
npm ERR!   @fengweichong/react-native-gzip@"*" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```

Create this PR, but I dont know which will be the last version to support? I suggest react >=16.8.1 would be ok?

Thanks!
